### PR TITLE
Add database feature

### DIFF
--- a/smpdf.py
+++ b/smpdf.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """ SMPDF """
+import os
+import os.path as osp
 import argparse
-import smpdflib as lib
+import shelve
 
 import matplotlib.pyplot as plt
 plt.style.use('main.mplstyle')
+
+import smpdflib as lib
 
 
 __author__ = 'Stefano Carrazza'
@@ -14,11 +18,10 @@ __version__ = '1.0.0'
 __email__ = 'stefano.carrazza@mi.infn.it'
 
 
-def main(conf):
+def main(conf, db):
     # perform convolution
     pdfsets, observables = conf['pdfsets'], conf['observables']
-    
-    results = lib.convolve_all(pdfsets, observables)
+    results = lib.convolve_or_load(pdfsets, observables, db)
     #TODO: load many replicas in C++
     for result in results:
         for member in result.iterall():
@@ -49,14 +52,34 @@ def splash():
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('config_yml', nargs='?',
+    parser.add_argument('config_yml',
                         help = "Path to the configuration file")
 
+    #TODO: Use db by default?
+    parser.add_argument('--use-db', nargs='?', help="Use Python database"
+    " file of results and do not recompute those already in there. "
+    "If a file is not passed 'db/db' will be used", metavar='dbfile', 
+    const='db/db', default=None)
+
     args = parser.parse_args()
-    if not (args.config_yml):
-        parser.error("Too few arguments: config_yml")
+    
     splash()
     # read yml file
     with open(args.config_yml,'r') as f:
         conf = lib.Config.from_yaml(f)
-    results = main(conf)
+    #TODO: handle this better
+    filename = args.use_db
+    if filename:
+        
+        dirname = osp.dirname(filename)
+        if dirname and not osp.isdir(dirname):
+            os.makedirs(dirname)
+        db = shelve.open(args.use_db)
+    else:
+        db = None
+    try:
+        results = main(conf, db=db)
+    finally:
+        #bool(db) == False if empty
+        if db is not None:
+            db.close()


### PR DESCRIPTION
With --use-db (file) results get cached in a database so they don't have
to be recomputed every time (especially inconvenient for developent). Of
course if the appl or lhapdf grids change, results will be wrong. It is
opt-on at the moment.
