### PR TITLE
Handle C++ errors

### DIFF
--- a/src/applwrap/applwrap.cc
+++ b/src/applwrap/applwrap.cc
@@ -5,11 +5,13 @@
 
 #include <Python.h>
 #include <LHAPDF/LHAPDF.h>
+#include <LHAPDF/Exceptions.h>
 #include <appl_grid/appl_grid.h>
 #include <appl_grid/appl_igrid.h>
 using std::vector;
 using std::cout;
 using std::endl;
+using std::exception;
 
 // I hate singletons - sc
 appl::grid *_g = nullptr;
@@ -39,7 +41,15 @@ static PyObject* py_initpdf(PyObject* self, PyObject* args)
     if (_pdfs[i]) delete _pdfs[i];
   _pdfs.clear();
 
-  _pdfs = LHAPDF::mkPDFs(setname);
+  try
+  {
+    _pdfs = LHAPDF::mkPDFs(setname);
+  }
+  catch (LHAPDF::Exception e)
+  {
+    PyErr_SetString(PyExc_ValueError, e.what());
+    return NULL;
+  }
   _imem = 0;
 
   return Py_BuildValue("");
@@ -60,7 +70,15 @@ static PyObject* py_initobs(PyObject* self, PyObject* args)
   PyArg_ParseTuple(args,"s", &file);
     
   if (_g) delete _g;
-  _g = new appl::grid(file);  
+  try
+  {
+    _g = new appl::grid(file);
+  }
+  catch(appl::grid::exception e)
+  {
+    PyErr_SetString(PyExc_ValueError, e.what());
+    return NULL;
+  }
 
   return Py_BuildValue("");
 }

--- a/src/applwrap/tests/test_applwrap.py
+++ b/src/applwrap/tests/test_applwrap.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Fri May 15 16:45:30 2015
+
+@author: zah
+"""
+import unittest
+
+import applwrap
+
+
+class TestConfig(unittest.TestCase):
+    def test_bad_values(self):
+        with self.assertRaises(ValueError):
+            applwrap.initobs("patata")
+        with self.assertRaises(ValueError):
+            applwrap.initpdf("patata")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Now LHAPDF and APPLGrid will raise Python exceptions instead of crashing
the interpreter, when their respective exceptions are triggered.
