### PR TITLE
new pdfcorr action

### DIFF
--- a/examples/pdfcorr.yaml
+++ b/examples/pdfcorr.yaml
@@ -1,0 +1,7 @@
+pdfsets :
+   - NNPDF30_nlo_as_0118
+   - MMHT2014nlo68cl
+actions:
+   - pdfcorr
+plot_Q: 1
+fmt: [png,pdf]

--- a/examples/pdfcorr.yaml
+++ b/examples/pdfcorr.yaml
@@ -1,7 +1,9 @@
 pdfsets :
    - NNPDF30_nlo_as_0118
    - MMHT2014nlo68cl
+   - mc2hessian_NNPDF30_nlo_as_0118_20
 actions:
    - pdfcorr
+base_pdf: NNPDF30_nlo_as_0118
 plot_Q: 1
 fmt: [png,pdf]

--- a/src/smpdflib/actions.py
+++ b/src/smpdflib/actions.py
@@ -102,6 +102,16 @@ def check_valid_smpdf_prior(action, group, config):
                " be one of %s") % (badstr, valid_errors)
         raise ActionError(msg)
 
+def check_valid_pdfcorr_prior(action, group, config):
+    valid_errors = set(("symmhessian","replicas","hessian"))
+    bad = [pdf for pdf in group["pdfsets"] if pdf.ErrorType
+                                              not in valid_errors]
+    if bad:
+        badstr = ', '.join(str(pdf) for pdf in bad)
+        msg = ("The PDF-PDF correlation cannot be constructed for: %s."
+               "The PDF ErrorType must be one of %s") % (badstr, valid_errors)
+        raise ActionError(msg)
+
 @check(check_know_errors)
 @require_args("plot_Q")
 def save_pdfplots(pdfsets, output_dir, prefix, plot_Q , plot_flavors=None,
@@ -121,6 +131,7 @@ def save_pdfplots(pdfsets, output_dir, prefix, plot_Q , plot_flavors=None,
                         prefix=prefix, fmt=fmt, namefunc=namefunc)
 
 @check(check_know_errors)
+@check(check_valid_pdfcorr_prior)
 @require_args("plot_Q")
 def save_pdfcorr(pdfsets, output_dir, prefix, plot_Q, plot_flavors=None,
                  base_pdf=None, fmt='pdf', photon=False):

--- a/src/smpdflib/actions.py
+++ b/src/smpdflib/actions.py
@@ -102,16 +102,6 @@ def check_valid_smpdf_prior(action, group, config):
                " be one of %s") % (badstr, valid_errors)
         raise ActionError(msg)
 
-def check_valid_pdfcorr_prior(action, group, config):
-    valid_errors = set(("symmhessian","replicas","hessian"))
-    bad = [pdf for pdf in group["pdfsets"] if pdf.ErrorType
-                                              not in valid_errors]
-    if bad:
-        badstr = ', '.join(str(pdf) for pdf in bad)
-        msg = ("The PDF-PDF correlation cannot be constructed for: %s."
-               "The PDF ErrorType must be one of %s") % (badstr, valid_errors)
-        raise ActionError(msg)
-
 @check(check_know_errors)
 @require_args("plot_Q")
 def save_pdfplots(pdfsets, output_dir, prefix, plot_Q , plot_flavors=None,
@@ -131,7 +121,6 @@ def save_pdfplots(pdfsets, output_dir, prefix, plot_Q , plot_flavors=None,
                         prefix=prefix, fmt=fmt, namefunc=namefunc)
 
 @check(check_know_errors)
-@check(check_valid_pdfcorr_prior)
 @require_args("plot_Q")
 def save_pdfcorr(pdfsets, output_dir, prefix, plot_Q, plot_flavors=None,
                  base_pdf=None, fmt='pdf', photon=False):

--- a/src/smpdflib/actions.py
+++ b/src/smpdflib/actions.py
@@ -120,6 +120,23 @@ def save_pdfplots(pdfsets, output_dir, prefix, plot_Q , plot_flavors=None,
                         output_dir,
                         prefix=prefix, fmt=fmt, namefunc=namefunc)
 
+@check(check_know_errors)
+@require_args("plot_Q")
+def save_pdfcorr(pdfsets, output_dir, prefix, plot_Q, plot_flavors=None,
+                 base_pdf=None, fmt='pdf', photon=False):
+    """
+    Generate PDF-PDF correlations at the scale plot_Q (given in GeV)
+    A subset of flavors can be passed as a list of PDG IDs.
+    """
+    import smpdflib.plots as plots
+    namefunc = lambda x: "pdfcorr_%s" % normalize_name(x)
+    return save_figures(plots.plot_pdfcorr(pdfsets,
+                            flavors=plot_flavors,
+                            Q=plot_Q,
+                            base_pdf=base_pdf, photon=photon),
+                        output_dir,
+                        prefix=prefix, fmt=fmt, namefunc=namefunc)
+
 
 @check(check_know_errors)
 def save_violins(results, output_dir, prefix, base_pdf=None, fmt='pdf'):
@@ -352,6 +369,7 @@ def install_grids(grid_names, output_dir):
 ACTION_DICT = OrderedDict((
                ('testas',  test_as_linearity),
                ('pdfplots',save_pdfplots),
+               ('pdfcorr', save_pdfcorr),
                ('violinplots',save_violins),
                ('ciplots',save_cis),
                ('asplots',save_as),

--- a/src/smpdflib/corrutils.py
+++ b/src/smpdflib/corrutils.py
@@ -16,6 +16,25 @@ def corrcoeff(prediction, pdf_val):
             (np.std(prediction,ddof=1)*np.std(pdf_val,ddof=1))
             )
 
+def corrcoeffhessian(pdf_val):
+    size = pdf_val.shape[0]
+    cc = np.zeros(shape=(size,size))
+    for i in range(size):
+        for j in range(i, size):
+            v1 = pdf_val[i,::2] - pdf_val[i,1::2]
+            v2 = pdf_val[j,::2] - pdf_val[j,1::2]
+            cc[i,j] = cc[j,i] = np.sum(v1*v2)/np.sum(v1**2)**0.5/np.sum(v2**2)**0.5
+    return cc
+
+def corrcoeffsymmhessian(central, pdf_val):
+    size = pdf_val.shape[0]
+    cc = np.zeros(shape=(size,size))
+    for i in range(size):
+        for j in range(i, size):
+            v1 = pdf_val[i,:] - central[i]
+            v2 = pdf_val[j,:] - central[j]
+            cc[i,j] = cc[j,i] = np.sum(v1*v2)/np.sum(v1**2)**0.5/np.sum(v2**2)**0.5
+    return cc
 
 def bin_corrs_from_X(bin_val, X,
                      correlation_threshold=DEFAULT_CORRELATION_THRESHOLD):

--- a/src/smpdflib/plots.py
+++ b/src/smpdflib/plots.py
@@ -144,6 +144,7 @@ def plot_pdfcorr(pdfsets, Q, base_pdf=None, flavors=None, photon=False):
         r = make_pdfcorr_results(pdf, Q, flavors=flavors, xgrid=xgrid)
         if pdf == base_pdf:
             base_results = r
+            continue
         resultlists.append(r)
 
     for res in resultlists:

--- a/src/smpdflib/plots.py
+++ b/src/smpdflib/plots.py
@@ -155,9 +155,9 @@ def plot_pdfcorr(pdfsets, Q, base_pdf=None, flavors=None, photon=False):
         plt.grid(False)
         if base_pdf:
             plt.title("Correlations at $Q=%.2f$ GeV for\n%s-%s" %
-                      (Q, pdf.label, base_pdf.label), fontsize=15)
+                      (Q, res.pdf.label, base_pdf.label), fontsize=15)
         else:
-            plt.title("Correlations at $Q=%.2f$ GeV for\n%s" % (Q, pdf.label),
+            plt.title("Correlations at $Q=%.2f$ GeV for\n%s" % (Q, res.pdf.label),
                       fontsize=15)
 
         ylabels = [ '\n\n' + r'$%s$' % PDG_PARTONS[fl] for fl in flavors]


### PR DESCRIPTION
This implementation provides the PDF-PDF correlation for the input pdfsets at a given, mandatory, plot_Q. If a base_pdf is set, then it computes the difference between pdfsets and base_pdf. This implementation is sufficient for a future smpdfweb, however a couple of fine tunings are required:
- when using plot_flavors, the x- and y-axis labels are not perfectly aligned, and in some particular cases, e.g. only 1 flavor, they could be replaced directly by the x values.
- for this tool the base_pdf is not mandatory in the pdfsets, otherwise the user will always get a flat plot with base_pdf-base_pdf.
